### PR TITLE
OME customisations to make this role easier to use

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,6 @@
 ---
 # Certbot auto-renew cron job configuration (for certificate renewals).
 certbot_auto_renew: true
-certbot_auto_renew_user: "{{ ansible_user }}"
-certbot_auto_renew_hour: 3
-certbot_auto_renew_minute: 30
 certbot_auto_renew_options: "--quiet --no-self-upgrade"
 
 # Parameters used when creating new Certbot certs.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,14 +7,10 @@ certbot_auto_renew_options: "--quiet --no-self-upgrade"
 certbot_create_if_missing: no
 certbot_create_method: standalone
 certbot_admin_email: email@example.com
-certbot_certs: []
-  # - email: janedoe@example.com
-  #   domains:
+certbot_domains:
   #     - example1.com
   #     - example2.com
-  # - domains:
-  #     - example3.com
-certbot_create_command: "{{ certbot_script }} certonly --standalone --noninteractive --agree-tos --email {{ cert_item.email | default(certbot_admin_email) }} -d {{ cert_item.domains | join(',') }}"
+certbot_create_command: "{{ certbot_script }} certonly --standalone --noninteractive --agree-tos --email {{ certbot_admin_email }} -d {{ certbot_domains | join(',') }}"
 certbot_create_standalone_stop_services:
   - nginx
   # - apache

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 # Certbot auto-renew cron job configuration (for certificate renewals).
 certbot_auto_renew: true
-certbot_auto_renew_options: "--quiet --no-self-upgrade"
+certbot_auto_renew_options: >
+  --quiet
+  --no-self-upgrade
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: no
@@ -10,7 +12,14 @@ certbot_admin_email: email@example.com
 certbot_domains:
   #     - example1.com
   #     - example2.com
-certbot_create_command: "{{ certbot_script }} certonly --standalone --noninteractive --agree-tos --email {{ certbot_admin_email }} -d {{ certbot_domains | join(',') }}"
+certbot_create_command: >
+  {{ certbot_script }}
+  certonly
+  --standalone
+  --noninteractive
+  --agree-tos
+  --email {{ certbot_admin_email }}
+  -d {{ certbot_domains | join(',') }}
 certbot_create_standalone_stop_services:
   - nginx
   # - apache

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ certbot_auto_renew: true
 certbot_auto_renew_options: >
   --quiet
   --no-self-upgrade
+  {{ certbot_auto_renew_args }}
+certbot_auto_renew_args: ""
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: no
@@ -20,8 +22,10 @@ certbot_create_command: >
   --agree-tos
   --email {{ certbot_admin_email }}
   -d {{ certbot_domains | join(',') }}
+  {{ certbot_create_args }}
+certbot_create_args: ""
 certbot_create_standalone_stop_services:
-  - nginx
+  # - nginx
   # - apache
   # - varnish
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ certbot_auto_renew_options: >
   --no-self-upgrade
   {{ certbot_auto_renew_args }}
 certbot_auto_renew_args: ""
+# Post-renewal commands to run, e.g. to restart services
+certbot_auto_renew_deploy_hooks: []
 
 # Parameters used when creating new Certbot certs.
 certbot_create_if_missing: no

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -12,7 +12,7 @@
   with_items: "{{ certbot_create_standalone_stop_services }}"
 
 - name: Generate new certificate if one doesn't exist.
-  shell: "{{ certbot_create_command }}"
+  command: "{{ certbot_create_command }}"
   when: not letsencrypt_cert.stat.exists
 
 - name: Start services after cert has been generated.

--- a/tasks/create-cert-standalone.yml
+++ b/tasks/create-cert-standalone.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check if certificate already exists.
   stat:
-    path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
+    path: /etc/letsencrypt/live/{{ certbot_domains | first }}/cert.pem
   register: letsencrypt_cert
 
 - name: Stop services to allow certbot to generate a cert.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,7 @@
   when: certbot_install_from_source
 
 - include: create-cert-standalone.yml
-  with_items: "{{ certbot_certs }}"
-  when:
-    - certbot_create_if_missing
-    - certbot_create_method == 'standalone'
-  loop_control:
-    loop_var: cert_item
+  when: certbot_create_if_missing
 
 - include: renew-cron.yml
   when: certbot_auto_renew

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
-- import_tasks: include-vars.yml
+- include: include-vars.yml
 
-- import_tasks: install-with-package.yml
+- include: install-with-package.yml
   when: not certbot_install_from_source
 
-- import_tasks: install-from-source.yml
+- include: install-from-source.yml
   when: certbot_install_from_source
 
-- include_tasks: create-cert-standalone.yml
+- include: create-cert-standalone.yml
   with_items: "{{ certbot_certs }}"
   when:
     - certbot_create_if_missing
@@ -15,5 +15,5 @@
   loop_control:
     loop_var: cert_item
 
-- import_tasks: renew-cron.yml
+- include: renew-cron.yml
   when: certbot_auto_renew

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -1,8 +1,6 @@
 ---
 - name: Add cron job for certbot renewal (if configured).
-  cron:
-    name: Certbot automatic renewal.
-    job: "{{ certbot_script }} renew {{ certbot_auto_renew_options }}"
-    minute: "{{ certbot_auto_renew_minute }}"
-    hour: "{{ certbot_auto_renew_hour }}"
-    user: "{{ certbot_auto_renew_user }}"
+  template:
+    src: cron-daily-certbot-renew.j2
+    dest: /etc/cron.daily/certbot-renew
+    mode: 0755

--- a/tasks/renew-cron.yml
+++ b/tasks/renew-cron.yml
@@ -4,3 +4,9 @@
     src: cron-daily-certbot-renew.j2
     dest: /etc/cron.daily/certbot-renew
     mode: 0755
+
+- name: Add renewal deploy hooks
+  template:
+    src: letsencrypt-renewal-hooks-deploy-commands.j2
+    dest: /etc/letsencrypt/renewal-hooks/deploy/commands.sh
+    mode: 0755

--- a/templates/cron-daily-certbot-renew.j2
+++ b/templates/cron-daily-certbot-renew.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+{{ certbot_script }} renew {{ certbot_auto_renew_options }}

--- a/templates/letsencrypt-renewal-hooks-deploy-commands.j2
+++ b/templates/letsencrypt-renewal-hooks-deploy-commands.j2
@@ -1,0 +1,4 @@
+#!/bin/sh
+{% for command in certbot_auto_renew_deploy_hooks %}
+{{ command }}
+{% endfor %}


### PR DESCRIPTION
- Compatible with Ansible 2.3
- Passes ansible-lint
- Make it easier to configure for OME use without overriding all arguments

This has been used to deploy a Let's Encrypt certificate in https://github.com/openmicroscopy/prod-playbooks/pull/93